### PR TITLE
using react query example causing an error

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,7 @@
     "@radix-ui/react-slot": "^1.3.3",
     "@radix-ui/react-tabs": "^1.1.21",
     "@sentry/nextjs": "10.45.0",
-    "@tanstack/react-query": "https://pkg.pr.new/@tanstack/react-query@10366",
+    "@tanstack/react-query": "https://pkg.pr.new/@tanstack/react-query@11237",
     "@tanstack/react-table": "9.0.0",
     "@tanstack/table-core": "9.0.0",
     "@types/pako": "^2.0.4",

--- a/apps/web/src/app/page-speed/[publicId]/page.tsx
+++ b/apps/web/src/app/page-speed/[publicId]/page.tsx
@@ -1,7 +1,7 @@
 import { LoadingMessage } from "@/components/common/LoadingMessage";
 import { ErrorMessage } from "@/components/common/ErrorMessage";
 import { Suspense, ViewTransition } from "react";
-import { ClientOnly } from "@/components/common/ClientOnly";
+
 import { PageSpeedInsightsDashboardContent } from "./PageSpeedInsightsDashboardWrapper";
 
 export default async function PageSpeedPublicIdPage({
@@ -10,7 +10,7 @@ export default async function PageSpeedPublicIdPage({
   params: Promise<{ publicId: string }>;
 }) {
   const { publicId } = await params;
-
+  console.log("in page.tsx on server");
   return (
     <ViewTransition>
       <ErrorMessage>

--- a/apps/web/src/features/page-speed-insights/data/usePageSpeedInsightsQuery.test.tsx
+++ b/apps/web/src/features/page-speed-insights/data/usePageSpeedInsightsQuery.test.tsx
@@ -1,11 +1,19 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, screen } from "@testing-library/react";
-import React, { Suspense } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Suspense, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { usePageSpeedInsightsQueryByPublicId } from "@/features/page-speed-insights/data/usePageSpeedInsightsQuery";
-import {
-  clearPageSpeedInsightsByPublicIdCache,
-  type PageSpeedLoadResult,
-} from "@/lib/page-speed-insights/pageSpeedInsightsClient";
+import type { PageSpeedLoadResult } from "@/lib/page-speed-insights/pageSpeedInsightsClient";
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
 
 function HookProbe({
   publicId,
@@ -16,25 +24,35 @@ function HookProbe({
 }) {
   const state = usePageSpeedInsightsQueryByPublicId(publicId);
   onResult(state);
-  return React.createElement("div", { "data-testid": "hook-result" }, JSON.stringify(state));
+  return <div data-testid="hook-result">{JSON.stringify(state)}</div>;
 }
 
-async function renderHookProbe(publicId: string) {
+function HookProbeProviders({
+  children,
+  queryClient,
+}: {
+  children: ReactNode;
+  queryClient: QueryClient;
+}) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Suspense fallback={<div data-testid="suspense-fallback">loading</div>}>{children}</Suspense>
+    </QueryClientProvider>
+  );
+}
+
+async function renderHookProbe(publicId: string, queryClient = createQueryClient()) {
   let latest: PageSpeedLoadResult | undefined;
   await act(async () => {
     render(
-      React.createElement(
-        Suspense,
-        {
-          fallback: React.createElement("div", { "data-testid": "suspense-fallback" }, "loading"),
-        },
-        React.createElement(HookProbe, {
-          publicId,
-          onResult: (state) => {
+      <HookProbeProviders queryClient={queryClient}>
+        <HookProbe
+          publicId={publicId}
+          onResult={(state) => {
             latest = state;
-          },
-        }),
-      ),
+          }}
+        />
+      </HookProbeProviders>,
     );
   });
   return {
@@ -43,10 +61,6 @@ async function renderHookProbe(publicId: string) {
 }
 
 describe("usePageSpeedInsightsQueryByPublicId", () => {
-  beforeEach(() => {
-    clearPageSpeedInsightsByPublicIdCache();
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -122,14 +136,15 @@ describe("usePageSpeedInsightsQueryByPublicId", () => {
     });
   });
 
-  it("reuses the same Promise across renders for a publicId", async () => {
+  it("reuses the cached query across renders for a publicId", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
       text: async () => JSON.stringify([]),
     } as Response);
 
-    await renderHookProbe("public-123");
-    await renderHookProbe("public-123");
+    const queryClient = createQueryClient();
+    await renderHookProbe("public-123", queryClient);
+    await renderHookProbe("public-123", queryClient);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/features/page-speed-insights/data/usePageSpeedInsightsQuery.ts
+++ b/apps/web/src/features/page-speed-insights/data/usePageSpeedInsightsQuery.ts
@@ -1,12 +1,19 @@
 "use client";
 import { use } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import {
-  fetchPageSpeedInsightsByPublicId,
+  getPageSpeedInsightsByPublicId,
   type PageSpeedLoadResult,
 } from "@/lib/page-speed-insights/pageSpeedInsightsClient";
 import { browser } from "react-dom";
 
 export function usePageSpeedInsightsQueryByPublicId(publicId: string): PageSpeedLoadResult {
   use(browser());
-  return use(fetchPageSpeedInsightsByPublicId(publicId));
+  const { data } = useSuspenseQuery({
+    queryKey: ["pageSpeed", "publicId", publicId] as const,
+    queryFn: ({ signal }: { signal: AbortSignal }) => {
+      return getPageSpeedInsightsByPublicId(publicId, signal);
+    },
+  });
+  return data;
 }

--- a/apps/web/src/lib/page-speed-insights/pageSpeedInsightsClient.ts
+++ b/apps/web/src/lib/page-speed-insights/pageSpeedInsightsClient.ts
@@ -22,10 +22,14 @@ function parsePageSpeedInsightsArrayFromText(text: string): PageSpeedInsightsArr
   return null;
 }
 
-async function getPageSpeedInsightsByPublicId(publicId: string): Promise<PageSpeedLoadResult> {
+export async function getPageSpeedInsightsByPublicId(
+  publicId: string,
+  signal?: AbortSignal,
+): Promise<PageSpeedLoadResult> {
   const res = await fetch(PAGE_SPEED_GET_BY_PUBLIC_ID(publicId), {
     method: "GET",
     headers: { "Content-Type": "application/json" },
+    signal,
   });
 
   if (res.status === 500) {
@@ -58,53 +62,4 @@ async function getPageSpeedInsightsByPublicId(publicId: string): Promise<PageSpe
   return { status: "ok", data };
 }
 
-type PendingPromise<T> = Promise<T> & {
-  status: "pending";
-};
 
-type FulfilledPromise<T> = Promise<T> & {
-  status: "fulfilled";
-  value: T;
-};
-
-type RejectedPromise<T> = Promise<T> & {
-  status: "rejected";
-  reason: unknown;
-};
-
-type PromiseWithStatus<T> = PendingPromise<T> | FulfilledPromise<T> | RejectedPromise<T>;
-
-/** Module-level cache so `use()` reuses the same Promise across re-renders. */
-const cache = new Map<string, PromiseWithStatus<PageSpeedLoadResult>>();
-
-export function fetchPageSpeedInsightsByPublicId(
-  publicId: string,
-): PromiseWithStatus<PageSpeedLoadResult> {
-  if (!cache.has(publicId)) {
-    const promise = getPageSpeedInsightsByPublicId(publicId) as PromiseWithStatus<PageSpeedLoadResult>;
-    promise.status = "pending";
-    promise.then(
-      (value) => {
-        const fulfilled = promise as FulfilledPromise<PageSpeedLoadResult>;
-        fulfilled.status = "fulfilled";
-        fulfilled.value = value;
-      },
-      (reason: unknown) => {
-        const rejected = promise as RejectedPromise<PageSpeedLoadResult>;
-        rejected.status = "rejected";
-        rejected.reason = reason;
-      },
-    );
-    cache.set(publicId, promise);
-  }
-  return cache.get(publicId)!;
-}
-
-/** Test helper / refresh: drop a cached Promise so the next fetch starts fresh. */
-export function clearPageSpeedInsightsByPublicIdCache(publicId?: string) {
-  if (publicId === undefined) {
-    cache.clear();
-    return;
-  }
-  cache.delete(publicId);
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: 10.45.0
         version: 10.45.0(@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.3.1-canary.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.3.0-canary-ec61f187-20260806(react@19.3.0-canary-ec61f187-20260806))(react@19.3.0-canary-ec61f187-20260806))(react@19.3.0-canary-ec61f187-20260806)(webpack@5.106.0(esbuild@0.28.2)(lightningcss@1.32.0)(postcss@8.5.26))
       '@tanstack/react-query':
-        specifier: https://pkg.pr.new/@tanstack/react-query@10366
-        version: https://pkg.pr.new/@tanstack/react-query@10366(react@19.3.0-canary-ec61f187-20260806)
+        specifier: https://pkg.pr.new/@tanstack/react-query@11237
+        version: https://pkg.pr.new/@tanstack/react-query@11237(react@19.3.0-canary-ec61f187-20260806)
       '@tanstack/react-table':
         specifier: 9.0.0
         version: 9.0.0(react-dom@19.3.0-canary-ec61f187-20260806(react@19.3.0-canary-ec61f187-20260806))(react@19.3.0-canary-ec61f187-20260806)
@@ -192,10 +192,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.6
-        version: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0)
+        version: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@28.1.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@28.1.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0))
 
   apps/worker:
     devDependencies:
@@ -358,8 +358,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@csstools/color-helpers@6.1.0':
-    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
     engines: {node: '>=20.19.0'}
 
   '@csstools/css-calc@3.3.0':
@@ -369,8 +369,8 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.10':
-    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -382,8 +382,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.7':
-    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -3026,13 +3026,13 @@ packages:
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
-  '@tanstack/query-core@https://pkg.pr.new/TanStack/query/@tanstack/query-core@a5fec0f':
-    resolution: {tarball: https://pkg.pr.new/TanStack/query/@tanstack/query-core@a5fec0f}
-    version: 5.96.0
+  '@tanstack/query-core@https://pkg.pr.new/TanStack/query/@tanstack/query-core@c0c7462':
+    resolution: {tarball: https://pkg.pr.new/TanStack/query/@tanstack/query-core@c0c7462}
+    version: 5.101.4
 
-  '@tanstack/react-query@https://pkg.pr.new/@tanstack/react-query@10366':
-    resolution: {tarball: https://pkg.pr.new/@tanstack/react-query@10366}
-    version: 5.96.0
+  '@tanstack/react-query@https://pkg.pr.new/@tanstack/react-query@11237':
+    resolution: {tarball: https://pkg.pr.new/@tanstack/react-query@11237}
+    version: 5.101.4
     peerDependencies:
       react: ^18 || ^19
 
@@ -3911,6 +3911,9 @@ packages:
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-toolkit@1.50.0:
     resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
@@ -5183,8 +5186,8 @@ packages:
       uglify-js:
         optional: true
 
-  terser@5.49.2:
-    resolution: {integrity: sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==}
+  terser@5.50.0:
+    resolution: {integrity: sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5634,7 +5637,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
       '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
     optional: true
@@ -5790,7 +5793,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@csstools/color-helpers@6.1.0':
+  '@csstools/color-helpers@6.1.1':
     optional: true
 
   '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -5799,9 +5802,9 @@ snapshots:
       '@csstools/css-tokenizer': 4.0.0
     optional: true
 
-  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 6.1.0
+      '@csstools/color-helpers': 6.1.1
       '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
@@ -5812,7 +5815,7 @@ snapshots:
       '@csstools/css-tokenizer': 4.0.0
     optional: true
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
     optional: true
@@ -8105,11 +8108,11 @@ snapshots:
       postcss: 8.5.26
       tailwindcss: 4.3.3
 
-  '@tanstack/query-core@https://pkg.pr.new/TanStack/query/@tanstack/query-core@a5fec0f': {}
+  '@tanstack/query-core@https://pkg.pr.new/TanStack/query/@tanstack/query-core@c0c7462': {}
 
-  '@tanstack/react-query@https://pkg.pr.new/@tanstack/react-query@10366(react@19.3.0-canary-ec61f187-20260806)':
+  '@tanstack/react-query@https://pkg.pr.new/@tanstack/react-query@11237(react@19.3.0-canary-ec61f187-20260806)':
     dependencies:
-      '@tanstack/query-core': https://pkg.pr.new/TanStack/query/@tanstack/query-core@a5fec0f
+      '@tanstack/query-core': https://pkg.pr.new/TanStack/query/@tanstack/query-core@c0c7462
       react: 19.3.0-canary-ec61f187-20260806
 
   '@tanstack/react-store@0.11.1(react-dom@19.3.0-canary-ec61f187-20260806(react@19.3.0-canary-ec61f187-20260806))(react@19.3.0-canary-ec61f187-20260806)':
@@ -8352,7 +8355,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@28.1.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@28.1.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -8363,13 +8366,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -8720,7 +8723,7 @@ snapshots:
   cssstyle@6.2.0:
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
-      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
       css-tree: 3.2.1
       lru-cache: 11.5.2
     optional: true
@@ -8888,6 +8891,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.3.1: {}
+
+  es-module-lexer@2.3.2: {}
 
   es-toolkit@1.50.0: {}
 
@@ -10528,14 +10533,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.49.2
+      terser: 5.50.0
       webpack: 5.106.0(esbuild@0.28.2)(lightningcss@1.32.0)(postcss@8.5.26)
     optionalDependencies:
       esbuild: 0.28.2
       lightningcss: 1.32.0
       postcss: 8.5.26
 
-  terser@5.49.2:
+  terser@5.50.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.18.0
@@ -10704,7 +10709,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0):
+  vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -10717,13 +10722,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
-      terser: 5.49.2
+      terser: 5.50.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@28.1.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@28.1.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -10740,7 +10745,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -10790,7 +10795,7 @@ snapshots:
       browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.5
-      es-module-lexer: 2.3.1
+      es-module-lexer: 2.3.2
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1


### PR DESCRIPTION
This function 

``` jsx 
export function usePageSpeedInsightsQueryByPublicId(publicId: string): PageSpeedLoadResult {
  use(browser());
  const { data } = useSuspenseQuery({
    queryKey: ["pageSpeed", "publicId", publicId] as const,
    queryFn: ({ signal }: { signal: AbortSignal }) => {
      return getPageSpeedInsightsByPublicId(publicId, signal);
    },
  });
  return data;
}
```

is causing the following error
``` 
Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem.
TypeError: Cannot read properties of null (reading 'use')
    at AbortSignal._temp (.next/dev/server/chunks/ssr/apps_web_src_features_page-speed-insights_0lls7_4._.js:66:424)
⨯ uncaughtException: TypeError: Cannot read properties of null (reading 'use')
    at AbortSignal._temp (.next/dev/server/chunks/ssr/apps_web_src_features_page-speed-insights_0lls7_4._.js:66:424)
⨯ uncaughtException:  TypeError: Cannot read properties of null (reading 'use')
    at AbortSignal._temp (.next/dev/server/chunks/ssr/apps_web_src_features_page-speed-insights_0lls7_4._.js:66:424)
```

AI summary of issue 

The error comes from a conflict in your recent `usePageSpeedInsightsQuery` change — specifically mixing React 19’s client-only bailout with TanStack Query suspense on the server.

## Root cause

In `usePageSpeedInsightsQuery.ts` you now have both:

```10:20:apps/web/src/features/page-speed-insights/data/usePageSpeedInsightsQuery.ts
export function usePageSpeedInsightsQueryByPublicId(publicId: string): PageSpeedLoadResult {
  use(browser());
  const { data } = useSuspenseQuery({
    queryKey: ["pagespeed", "publicId", publicId] as const,
    queryFn: ({ signal }: { signal: AbortSignal }) => {
      return getPageSpeedInsightsByPublicId(publicId, signal);
    },
  });
  return data;
}
```

Those two patterns fight each other:

1. **`use(browser())`** — React 19’s “client only” API. On the server it throws a promise so rendering defers to the browser.
2. **`useSuspenseQuery`** — also uses `React.use()` internally for suspense.

During SSR, Next still tries to render this hook inside `<Suspense>` in your page:

```14:21:apps/web/src/app/page-speed/[publicId]/page.tsx
  return (
    <ViewTransition>
      <ErrorMessage>
        <Suspense fallback={<LoadingMessage />}>
          <PageSpeedInsightsDashboardContent publicId={publicId} />
        </Suspense>
      </ErrorMessage>
    </ViewTransition>
  );
```

That combination can leave React’s hook dispatcher as `null` when `use()` runs again, which produces:

> `Cannot read properties of null (reading 'use')`

The stack frame `AbortSignal._temp` is a source-map name for your `queryFn` callback (from `{ signal: AbortSignal }`), not proof that `AbortSignal` itself is the problem.

## Why it repeats

The errors fire on every request to `/page-speed/...` because SSR keeps hitting this hook. The page can still return 200 (you’ll see successful API calls in the log), but the server throws uncaught exceptions along the way.

## How to fix it

Pick one strategy — don’t combine client-only bailout with suspense query in the same hook.

**Option A — Client-only fetch (matches your old `use(fetch(...))` intent)**

- Wrap the dashboard in `<ClientOnly>` in `page.tsx` (it’s imported but unused).
- Remove `use(browser())` from the hook (the wrapper handles client-only).
- Keep `useSuspenseQuery` if you want React Query caching.

**Option B — SSR suspense fetch**

- Remove `use(browser())` from the hook.
- Keep `<Suspense>` + `useSuspenseQuery` so the server can suspend and show `LoadingMessage`.

**Option C — Minimal revert**

- Drop `useSuspenseQuery` and go back to `return use(fetchPageSpeedInsightsByPublicId(publicId))` if you don’t need React Query here yet.

The core issue: **`use(browser())` and `useSuspenseQuery` both call `React.use()`, but they assume different render environments.** On the server that blows up.

Want me to apply one of these fixes? Option A or B is the cleanest depending on whether you want client-only or SSR data loading.
